### PR TITLE
Bump workos to 0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'sinatra-contrib'
-gem 'workos', git: 'https://github.com/workos-inc/workos-ruby', branch: 'master'
+gem 'workos', '0.1.1'
 gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'sinatra-contrib'
-gem 'workos', git: 'https://github.com/workos-inc/workos-ruby', branch: 'sbauch/add-draft-connection-promotion'
+gem 'workos', git: 'https://github.com/workos-inc/workos-ruby', branch: 'master'
 gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/workos-inc/workos-ruby
-  revision: bf4da2c60276117d6a47a9c6118e2e0036f00032
-  branch: master
-  specs:
-    workos (0.1.1)
-      sorbet-runtime (~> 0.5)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -36,6 +28,8 @@ GEM
       tilt (~> 2.0)
     sorbet-runtime (0.5.5434)
     tilt (2.0.10)
+    workos (0.1.1)
+      sorbet-runtime (~> 0.5)
 
 PLATFORMS
   ruby
@@ -44,7 +38,7 @@ DEPENDENCIES
   faker
   sinatra
   sinatra-contrib
-  workos!
+  workos (= 0.1.1)
 
 BUNDLED WITH
    2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/workos-inc/workos-ruby
-  revision: 320835db73fe43c219afdbdbc1739701ff9f51d8
-  branch: sbauch/add-draft-connection-promotion
+  revision: bf4da2c60276117d6a47a9c6118e2e0036f00032
+  branch: master
   specs:
     workos (0.1.1)
       sorbet-runtime (~> 0.5)
@@ -9,7 +9,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.16.1)
+    backports (3.17.0)
     concurrent-ruby (1.1.6)
     faker (2.10.2)
       i18n (>= 1.6, < 2)
@@ -34,7 +34,7 @@ GEM
       rack-protection (= 2.0.8.1)
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
-    sorbet-runtime (0.5.5376)
+    sorbet-runtime (0.5.5434)
     tilt (2.0.10)
 
 PLATFORMS


### PR DESCRIPTION
## Description

This PR removes a nonexistent `Gemfile.lock` git revision that was associated with the `workos` gem we're installing from the [workos-ruby](https://github.com/workos-inc/workos-ruby/) repo.

We're removing this revision by updating the reference branch used by the `workos` gem.

---

WorkOS.js widget [Deploy to Heroku](https://heroku.com/deploy) builds were failing like so:
```
-----> Ruby app detected
-----> Installing bundler 2.0.2
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rack
-----> Using Ruby version: ruby-2.6.5
-----> Installing dependencies using bundler 2.0.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Fetching gem metadata from https://rubygems.org/..........
       Fetching https://github.com/workos-inc/workos-ruby
       fatal: Could not parse object '320835db73fe43c219afdbdbc1739701ff9f51d8'.
       Revision 320835db73fe43c219afdbdbc1739701ff9f51d8 does not exist in the
       repository https://github.com/workos-inc/workos-ruby. Maybe you misspelled it?
       Bundler Output: Fetching gem metadata from https://rubygems.org/..........
       Fetching https://github.com/workos-inc/workos-ruby
       fatal: Could not parse object '320835db73fe43c219afdbdbc1739701ff9f51d8'.
       Revision 320835db73fe43c219afdbdbc1739701ff9f51d8 does not exist in the
       repository https://github.com/workos-inc/workos-ruby. Maybe you misspelled it?
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```

I tried to remove and re-`bundle` the offending revision in the `Gemfile.lock` (per this [Semaphore doc](https://semaphoreci.com/docs/fail-could-not-parse-object.html)), but continued to receive:
```
idp-link-example on  master [!] via 💎 v2.6.5 took 3s
➜ bundle
Fetching https://github.com/workos-inc/workos-ruby
fatal: Needed a single revision
Git error: command `git rev-parse --verify sbauch/add-draft-connection-promotion` in directory /Users/th/idp-link-example has failed.
Revision sbauch/add-draft-connection-promotion does not exist in the repository https://github.com/workos-inc/workos-ruby. Maybe you misspelled it?
If this error persists you could try removing the cache directory '/Library/Ruby/Gems/2.6.0/cache/bundler/git/workos-ruby-f807414919254bf4ee1852fd539897752d55e87a'
```

So I learned [a bit](https://bundler.io/guides/git.html) about branch management when installing gems from git repos, and saw that we were referencing an outdated/nonexistent branch in our `Gemfile`.

## Type of change

- [x] Bug fix / chore (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related PRs / Issues

## Asana links

🎟 https://app.asana.com/0/1165454451722972/1166274731317219/f

## Testing plan
