### PR TITLE
Use create_connection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,9 +27,9 @@ GEM
       rack-protection (= 2.0.8.1)
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
-    sorbet-runtime (0.5.5460)
+    sorbet-runtime (0.5.5610)
     tilt (2.0.10)
-    workos (0.2.1)
+    workos (0.3.1)
       sorbet-runtime (~> 0.5)
 
 PLATFORMS

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Finally, using one of the WorkOS SDK's, confirm the pending IdP configuration wi
 
 ```ruby
 post '/confirm' do
-  WorkOS::SSO.promote_draft_connection(
-    token: params['token'],
+  WorkOS::SSO.create_connection(
+    source: params['token'],
   )
 end
 ```

--- a/app.rb
+++ b/app.rb
@@ -36,7 +36,7 @@ get '/' do
 end
 
 post '/confirm' do
-  WorkOS::SSO.promote_draft_connection(
-    token: params['token'],
+  WorkOS::SSO.create_connection(
+    source: params['token'],
   )
 end


### PR DESCRIPTION
Updates the ruby WorkOS package version to the latest and uses the new `create_connection` method.