### PR TITLE
Demo styling tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WorkOS.js is available as a Javascript embed via the WorkOS CDN. WorkOS is alway
 Then add an element to your DOM with the class `workos-container`
 
 ```html
-<div 
+<div
   class='workos-container'
   data-prop-publishable-key='WORKOS_PUBLISHABLE_KEY'
   data-prop-domain='CURRENT_USER_DOMAIN'
@@ -70,7 +70,7 @@ post '/confirm' do
 end
 ```
 
-See the relevant documentation in our (Node)[https://github.com/workos-inc/workos-node], (Go)[https://github.com/workos-inc/workos-go], (Python)[https://github.com/workos-inc/workos-python] or (Ruby)[https://github.com/workos-inc/workos-ruby] SDK.
+See the relevant documentation for our [Node](https://github.com/workos-inc/workos-node), [Go](https://github.com/workos-inc/workos-go), [Python](https://github.com/workos-inc/workos-python), [Ruby](https://github.com/workos-inc/workos-ruby) or [PHP](https://github.com/workos-inc/workos-php) SDKs.
 
 ### Try it Yourself
 

--- a/app.rb
+++ b/app.rb
@@ -32,7 +32,7 @@ get '/' do
   }
 
   @theme = {
-    org: params['org'] || 'WorkOS.js',
+    org: params['org'] || 'Cloud App',
     sidebar_color: params['sidebar_color'] || 'fff',
     bg_color: params['bg_color'] || 'fff'
   }

--- a/app.rb
+++ b/app.rb
@@ -32,8 +32,8 @@ get '/' do
   }
 
   @theme = {
-    org: params['org'] || 'Cloud App',
-    sidebar_color: params['sidebar_color'] || 'f6f4f4',
+    org: params['org'] || 'WorkOS.js',
+    sidebar_color: params['sidebar_color'] || 'fff',
     bg_color: params['bg_color'] || 'fff'
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,5 @@
+@import url(https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600&display=swap);
+
 * {
   margin: 0;
   padding: 0;
@@ -6,84 +8,58 @@
 
 body {
   color: #373737;
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: 'Open Sans', sans-serif;
   display: grid;
-  grid-template-columns: 315px auto;
-}
-
-.sidebar {
-  display: grid;
-  grid-template-columns: 75px 240px;
+  grid-template-columns: 240px auto;
   height: 100vh;
 }
 
-.navigation {
-  margin-top: 48px;
+.sidebar {
+  border-right: 1px solid #f3f3f3;
 }
-
 .sidebar-header {
-  padding: 16px 12px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  padding: 16px 12px;
+  border-bottom: 1px solid #f3f3f3;
+}
+
+.sidebar-header__logo {
+  font-size: 20px;
+  background-color: #383838;
+  padding: 2px 6px;
+  border-radius: 8px;
+  margin-right: 8px;
 }
 
 .sidebar-header__title {
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 29px;
+  font-weight: 600;
+  font-size: 18px;
 }
 
 .menu {
+  padding: 16px 12px;
+  font-weight: 300;
+  font-size: 14px;
+}
+
+.menu-item {
+  padding: 10px 8px;
+  display: flex;
+  align-items: center;
+}
+
+.menu-item__selected {
   box-shadow: 0px 2px 10px rgba(0, 0, 0, 0.08);
   border-radius: 4px;
-  height: 40px;
-  width: calc(100% - 24px);
-  margin-left: 12px;
 }
 
-.list {
-  margin-top: 48px;
-}
-
-.item {
-  list-style: none;
-  border-bottom: 1px solid #e0e0e0;
-  margin-bottom: 44px;
-}
-
-.channel {
-  padding-left: 6px;
-  padding-right: 12px;
-  margin-bottom: 12px;
-  border-left: 6px solid transparent;
-}
-
-.channel--active {
-  border-color: #373737;
-}
-
-.channel-item {
-  display: block;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-}
-
-.channel-item--dark {
-  background-color: #616165;
-}
-
-.channel-item--light {
-  background-color: #c4c4c4;
-}
-
-.channel-item--default {
-  background-color: #929292;
-}
-
-.channel-item--lighter {
-  background-color: #dcdcdc;
+.menu-item__icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+  stroke: #373737;
+  fill: none;
 }
 
 .content {

--- a/public/styles.css
+++ b/public/styles.css
@@ -17,6 +17,7 @@ body {
 .sidebar {
   border-right: 1px solid #f3f3f3;
 }
+
 .sidebar-header {
   display: flex;
   align-items: center;
@@ -76,6 +77,8 @@ body {
   font-size: 24px;
   line-height: 29px;
   margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #d0d0ce;
 }
 
 .form-field {
@@ -101,6 +104,7 @@ body {
   padding: 8px;
   width: 100%;
   display: block;
+  background-color: #fafbfc;
 }
 
 .workos-container {

--- a/views/index.erb
+++ b/views/index.erb
@@ -26,7 +26,7 @@
   </fieldset>
 
   <fieldset class="form-info">
-    <h2 class="form-info__title">Organization Settings</h2>
+    <h2 class="form-info__title">Admin Settings</h2>
 
     <div class="form-field">
       <div class="input-field">

--- a/views/index.erb
+++ b/views/index.erb
@@ -4,29 +4,29 @@
 
     <div class="form-field">
       <div class="input-field">
-        <label class="label" for="name">Name</label>
+        <label class="label" for="name">Full name</label>
         <input class="input" id="name" type="text" value="<%= @current_user[:name] %>" placeholder="John Smith" />
       </div>
 
       <div class="input-field">
-        <label class="label" for="password">New Password</label>
+        <label class="label" for="password">New password</label>
         <input class="input" id="password" type="password" />
       </div>
 
       <div class="input-field">
-        <label class="label" for="email">Email</label>
+        <label class="label" for="email">Email address</label>
         <input class="input" id="email" type="email" value="<%= @current_user[:email] %>" placeholder="user@foo-corp.com" >
       </div>
 
       <div class="input-field">
-        <label class="label" for="confirm_password">Repeat New Password</label>
+        <label class="label" for="confirm_password">Confirm new password</label>
         <input class="input" id="confirm_password" type="password" />
       </div>
     </div>
   </fieldset>
 
   <fieldset class="form-info">
-    <h2 class="form-info__title">App Settings</h2>
+    <h2 class="form-info__title">Organization Settings</h2>
 
     <div class="form-field">
       <div class="input-field">

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -6,41 +6,62 @@
   </head>
 
   <body style="background-color: #<%= @theme[:bg_color] %>;">
-    <aside class="sidebar">
-      <nav class="navigation">
-        <ul>
-          <li class="channel"><span class="channel-item channel-item--dark" /></li>
-          <li class="channel"><span class="channel-item channel-item--light" /></li>
-          <li class="channel"><span class="channel-item channel-item--default" /></li>
-          <li class="channel"><span class="channel-item channel-item--lighter" /></li>
-          <li class="channel"><span class="channel-item channel-item--dark" /></li>
-          <li class="channel"><span class="channel-item channel-item--default" /></li>
-          <li class="channel"><span class="channel-item channel-item--lighter" /></li>
-        </ul>
-      </nav>
+    <aside class="sidebar" style="background-color: #<%= @theme[:sidebar_color] %>;">
+      <header class="sidebar-header">
+        <span class="sidebar-header__logo">&#10024;</span>
+        <h1 class="sidebar-header__title"><%= @theme[:org] %></h1>
+      </header>
 
-      <div class="sidebar-menu" style="background-color: #<%= @theme[:sidebar_color] %>;">
-        <header class="sidebar-header">
-          <h1 class="sidebar-header__title"><%= @theme[:org] %></h1>
-
-          <svg width="16" height="4" viewBox="0 0 16 4" fill="none">
-            <circle cx="8" cy="2" r="2" fill="#373737"/>
-            <circle cx="14" cy="2" r="2" fill="#373737"/>
-            <circle cx="2" cy="2" r="2" fill="#373737"/>
-          </svg>
-
-        </header>
-
-        <div class="menu" style="background-color: #<%= @theme[:bg_color] %>;"></div>
-
-        <ul class="list">
-          <li class="item" />
-          <li class="item" />
-          <li class="item" />
-          <li class="item" />
-        </ul>
+      <div class="menu" style="background-color: #<%= @theme[:bg_color] %>;">
+        <div class="menu-item menu-item__selected">
+          <svg class="menu-item__icon settings-icon"><use stroke="#373737" xlink:href="#settings"></svg>
+          <span>Settings and Team</span>
+        </div>
+        <div class="menu-item">
+          <svg class="menu-item__icon home-icon"><use stroke="#59c197" xlink:href="#home"></svg>
+          <span>Home</span>
+        </div>
+        <div class="menu-item">
+          <svg class="menu-item__icon"><use stroke="#83b5db" xlink:href="#circle"></svg>
+          <span>...</span>
+        </div>
+        <div class="menu-item">
+          <svg class="menu-item__icon"><use stroke="#f2ca7a" xlink:href="#circle"></svg>
+          <span>...</span>
+        </div>
+        <div class="menu-item">
+          <svg class="menu-item__icon"><use stroke="#e08073" xlink:href="#circle"></svg>
+          <span>...</span>
+        </div>
       </div>
+
     </aside>
+
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      display="none"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      stroke-width="1"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <symbol id="settings">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </symbol>
+
+      <symbol id="home">
+        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+        <polyline points="9 22 9 12 15 12 15 22" />
+      </symbol>
+
+      <symbol id="circle">
+        <circle cx="12" cy="12" r="10" />
+      </symbol>
+
+    </svg>
 
     <%= yield %>
 


### PR DESCRIPTION
### Changes
- Minor styling tweaks to the workos.js demo. Rationale here is to make the demo a bit more relatable, so during demo calls, peoples' imaginations are captured more. I took cues from Clay, Slab, and Github.
- Fix linking in README

### Notes
If these changes get merged, let's wait till after demo call are done for the day before redeploying.

### Screenshots
Before
<img width="1440" alt="Screen Shot 2020-06-24 at 2 54 08 AM" src="https://user-images.githubusercontent.com/29710511/85588426-4a412b80-b608-11ea-913d-c4df082d7b0a.png">

After
<img width="1439" alt="Screen Shot 2020-06-24 at 10 43 15 AM" src="https://user-images.githubusercontent.com/29710511/85588534-6349dc80-b608-11ea-8e33-5c79e56930f3.png">
