### PR TITLE
Remove WorkOS.JS

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -64,7 +64,5 @@
     </svg>
 
     <%= yield %>
-
-    <script type="text/javascript" src="https://js.workos.com/v3"></script>
   </body>
 </html>


### PR DESCRIPTION
This was a left script tag of WorkOS.JS from when the demo app was focused on WorkOS.JS. Now that we are pointing towards the Admin Portal we will no longer be needing it. 