### PR TITLE
Use JWT to link directly to Admin Portal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+WORKOS_ADMIN_PORTAL_HOSTNAME=setup.workos-test.com
+WORKOS_API_HOSTNAME=api.workos-test.com
+WORKOS_KEY=SECRET_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@
 
 source 'https://rubygems.org'
 
+gem 'dotenv'
 gem 'faker'
+gem 'jwt'
 gem 'rack-ssl-enforcer'
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,12 @@ GEM
   specs:
     backports (3.17.0)
     concurrent-ruby (1.1.6)
+    dotenv (2.7.6)
     faker (2.10.2)
       i18n (>= 1.6, < 2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    jwt (2.2.2)
     multi_json (1.14.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -36,7 +38,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dotenv
   faker
+  jwt
   rack-ssl-enforcer
   sinatra
   sinatra-contrib

--- a/views/index.erb
+++ b/views/index.erb
@@ -32,6 +32,8 @@
           <div class="input-field">
             <label class="label">Single Sign-On</label>
 
+            <input hidden class="hidden-field" id="organization" name="organization" type="text" readonly value="<%= @organization.id %>">
+
             <button class="button-sso" type="submit">Configure SSO</button>
           </div>
         </div>


### PR DESCRIPTION
* Previously, the Admin Portal demo had some slowness due to the fact
  that we were setting up data when a user clicked "Configure SSO".
  With this PR we are instead eager loading that data on page load and
  then creating a JWT and redirecting directly to the Admin Portal with
  it.