### PR TITLE
Set the `key` field in the Admin Portal token

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -48,6 +48,7 @@ end
 
 post '/portal' do
   payload = {
+    key: ENV['WORKOS_KEY_ID'],
     intent: params[:intent],
     organization: params[:organization],
     scenario: params[:scenario],


### PR DESCRIPTION
This PR sets the `key` field in the Admin Portal token so we know which key was used to sign the token.

I already added the `WORKOS_KEY_ID` environment variable.