### PR TITLE
Add `robots.txt` and completely disallow demo site

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Even though the demo app is currently public, it doesn't provide any context for visitors who land on it directly from Google. Therefore, this adds a `robots.txt` to keep this site out of search results. 