### PR TITLE
Add Ruby version to `Gemfile` and lock file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+ruby "2.7.5"
+
 gem 'dotenv'
 gem 'faker'
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,5 +46,8 @@ DEPENDENCIES
   sinatra-contrib
   workos
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
[Heroku expects the required version to be specified in the Gemfile.](https://devcenter.heroku.com/articles/ruby-versions#selecting-a-version-of-ruby) It's also just good practice to specify the Ruby version there.